### PR TITLE
Add custom comment.

### DIFF
--- a/exampleSite/layouts/partials/comment.html
+++ b/exampleSite/layouts/partials/comment.html
@@ -1,0 +1,17 @@
+<script>
+  const repo = '{{ .Site.Params.utterances.repo }}'
+  const issueTerm = '{{ .Site.Params.utterances.issueTerm }}'
+  const theme = localStorage.theme ? `github-${localStorage.theme}` : 'preferred-color-scheme';
+
+  const script = document.createElement('script')
+  script.src = 'https://utteranc.es/client.js'
+  script.async = true
+  script.crossOrigin = 'anonymous'
+
+  script.setAttribute('repo', repo)
+  script.setAttribute('issue-term', issueTerm)
+  script.setAttribute('theme', theme)
+  script.setAttribute('label', 'comment')
+
+  document.querySelector('main').appendChild(script)
+</script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,9 +5,9 @@
 <h1 class="mt-6 mb-6">{{ .Title }}</h1>
 <div class="mb-3 text-xs flex justify-between sm:flex-col">
 	<div>
-	{{ if .Site.Params.displayDate }}
+		{{ if .Site.Params.displayDate }}
 		Posted at &mdash; {{ dateFormat .Site.Params.timeformat .Date }}
-	{{ end }}
+		{{ end }}
 		{{ if .Draft }}
 		<span class="ml-3 minima-tag">
 			DRAFT
@@ -37,16 +37,6 @@
 {{ end }}
 
 {{ if or .Params.comment (and .Site.Params.commentOnAllPosts (ne .Params.comment false)) }}
-	{{ if eq .Site.Params.comment "disqus"}}
-	{{ partial "disqus.html" . }}
-	{{ end }}
-
-	{{ if eq .Site.Params.comment "ovo"}}
-	{{ partial "ovo.html" . }}
-	{{ end }}
-
-	{{ if eq .Site.Params.comment "utterances"}}
-	{{ partial "utterances.html" . }}
-	{{ end }}
+	{{ partial "comment.html" . }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Makes some changes to support custom comment and other user's script.

Following is details in Chinese:

Hugo 会优先从用户的 layouts 读取 partials 而不是 themes
所以我删掉了原有的具体的评论实现，加入了一个 custom
如果需要引入评论的脚本
需要自己去对应插件的网站，把脚本和配置粘贴到 custom

我不知道能不能 merge，所以原有的相关配置文件没有动

(有个缩进的改动是不小心点了代码格式化hh)