### PR TITLE
Added support for comment label customization

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -62,6 +62,7 @@ shortname = "hugo-minima"
 [params.utterances]
 repo = "mivinci/hugo-theme-minima"
 issueTerm = "pathname"
+label = "comment"
 
 # **deprecated**
 # OvO is a comment plugin written by the author of Minima.

--- a/layouts/partials/utterances.html
+++ b/layouts/partials/utterances.html
@@ -2,6 +2,7 @@
   const repo = '{{ .Site.Params.utterances.repo }}'
   const issueTerm = '{{ .Site.Params.utterances.issueTerm }}'
   const theme = localStorage.theme ? `github-${localStorage.theme}` : 'preferred-color-scheme';
+  const label = '{{ .Site.Params.utterances.label }}'
 
   const script = document.createElement('script')
   script.src = 'https://utteranc.es/client.js'
@@ -11,7 +12,7 @@
   script.setAttribute('repo', repo)
   script.setAttribute('issue-term', issueTerm)
   script.setAttribute('theme', theme)
-  script.setAttribute('label', 'comment')
+  script.setAttribute('label', label ? label : 'comment')
 
   document.querySelector('main').appendChild(script)
 </script>


### PR DESCRIPTION
Sometimes it may be necessary to customize the label name. I have added support for this via giving a name in the config file.

Example

```toml
[params.utterances]
repo = "mivinci/hugo-theme-minima"
issueTerm = "pathname"
label = "blog-comment"
```