### PR TITLE
Added support for i18n url in main menu

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
     {{ $data := .Data }}
     {{ range $key, $value := .Data.Terms.ByCount }}
     <div class="mb-5 flex justify-between">
-      <a class="self-start" href="/{{ $data.Plural }}/{{ $value.Name }}">
+      <a class="self-start" href="{{ $data.Plural | absLangURL }}/{{ $value.Name }}">
         {{ $value.Name }}
       </a>
       <span class="">{{ $value.Count }}</span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
   <nav class="flex items-center
     whitespace-nowrap overflow-x-auto overflow-y-hidden">
     {{ range .Site.Menus.main }}
-    <a class="ml-5" href="{{ .URL }}">{{ .Name }}</a>
+    <a class="ml-5" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
     {{ end }}
   </nav>
 </header>


### PR DESCRIPTION
When multiple languages are used, the links in the main menu always lead to English. In this pull request, I added the absLangURL function with which, with support, the url of the current language is substituted.