### PR TITLE
Make Chroma line numbers unselectable

### DIFF
--- a/assets/css/syntax.scss
+++ b/assets/css/syntax.scss
@@ -38,6 +38,8 @@
   padding-right: 1em;
   text-align: right;
   user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
 }
 
 .chroma .hl .lnt {

--- a/assets/css/syntax.scss
+++ b/assets/css/syntax.scss
@@ -37,6 +37,7 @@
   padding-left: .9em;
   padding-right: 1em;
   text-align: right;
+  user-select: none;
 }
 
 .chroma .hl .lnt {


### PR DESCRIPTION
**Chroma's code line number should not be selectable**

Before:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/57177121/236653058-3c039a48-3cf1-4d01-a532-511098adf91e.png">

After:

<img width="686" alt="image" src="https://user-images.githubusercontent.com/57177121/236653076-9f91f699-5f18-40a6-8b8b-9377d17c2c53.png">
