### PR TITLE
hide language menu when there is no translation

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,11 +19,13 @@
         </li>
         {{ end }}
       </ul>
+      {{ if gt (len $.Site.Home.AllTranslations) 1 }}
       <ul class="flex item-center text-sm font-semibold">
         {{ range $.Site.Home.AllTranslations }}
         <li class="ml-2"><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
         {{ end}}
       </ul>
+      {{ end }}
     </nav>
   </div>
 </header>


### PR DESCRIPTION
When the language menu is empty, the main menu is not right-aligned, this PR hide the language menu when there is no translation.